### PR TITLE
Audio and 3D static metadata updates

### DIFF
--- a/Drafts/AudioAssetMetadata.md
+++ b/Drafts/AudioAssetMetadata.md
@@ -4,8 +4,8 @@ status: Draft
 author: Christian Sumido (@gcbsumid)
 discussions-to: https://discord.gg/Ge2j4Cd65H
 created: 2021-08-30
-updated: 2021-11-10
-version: 0.3
+updated: 2022-01-31
+version: 0.4
 ---
 
 # Audio Asset Metadata

--- a/Drafts/AudioAssetMetadata.md
+++ b/Drafts/AudioAssetMetadata.md
@@ -34,8 +34,6 @@ Note: these audio duration requirements are not final and can be changed upon co
 
 Note: Unity has great flexibility on which audio assets should be kept in memory at all times. The game developer should honor the requirements for the framework in order to optimize memory usage. 
 
-Note: Each game must know what engine and platform they are running on. They must know which audio package to download and load for their game.
-
 ### Supported Formats
 Format | Extension
 ------ | ------
@@ -60,6 +58,10 @@ The character lines subtype requires that the audio file has a maximum duration 
 
 The background music subtype requires that the audio file has a maximum duration of 300 seconds. Background Music assets are loaded per gamer and not shared during gameplay. They may also be loaded gradually or on demand. They shouldn't be kept in memory.
 
+### Custom Subtype
+
+The custom subtype doesn't have a maximum duration for the audio. The creator is free to choose what they want to use in their games and NFT. The custom subtype, however, may not be loadable in other games aside from the creator's game. It is up to the game developer whether or not to support custom assets from other games.
+
 ### Schema 
 ```
 {
@@ -79,19 +81,11 @@ The background music subtype requires that the audio file has a maximum duration
     "properties": {
         "name": {
             "type": "string",
-            "description": "name of the AudioClip that's stored in the package"
-        },
-        "engine": {
-            "type": "string",
-            "description": "engine which this package supports. Values include none, unity, and unreal. none refers to the raw, uncompressed, unpackaged file for use by dapps."
-        },
-        "compression": {
-            "type": "string",
-            "description": "specifies the compression algorithm used when the audio file was packaged. For Unity, these values can be PCM, ADPCM, or Compressed. Compressed is the default common value."
+            "description": "name of the audio file - optional"
         },
         "uri": {
             "type": "string",
-            "description": "uri to the downloadable file or audio package"
+            "description": "uri to the downloadable audio file"
         },
         "contentType": {
             "type": "string",
@@ -100,45 +94,21 @@ The background music subtype requires that the audio file has a maximum duration
         "duration": {
             "type": "int",
             "description": "duration of the audio clip in milliseconds"
-        },
-        "channelCount": {
-            "type": "int",
-            "description": "channel count of the audio clip"
-        },
-        "sampleRate": {
-            "type": "int",
-            "description-hz": "sample rate of the audio clip in Hz"
-        },
+        }
     }
 }
 ```
 
 ## Rationale
 
-For the audio asset metadata, the developer can add as many audio packages to the NFT as they need. Each `audio` subtype has its own specific requirements so that game developers know how to properly load assets and when/how to use them in their game. The specific requirements for each audio subtype is `duration` and load type. The sound effects and shout subtypes should be kept in memory when loaded in game so the gamers may use them whenever possible. The character lines and background music subtype should be loaded on demand and the developer may choose when to load them in-game. Limiting `duration` for each subtype specifies each subtype's use case and limits the asset file size.
+For the audio asset metadata, the developer can add as many audio asset properties to the NFT as they need so it provides the game developer a choice of which audio file to use. Each `audio` subtype has its own specific requirements so that game developers know how to properly load assets and when/how to use them in their game. The specific requirements for each audio subtype is `duration` and load type. The sound effects and shout subtypes should be kept in memory when loaded in game so the gamers may use them whenever possible. The character lines and background music subtype should be loaded on demand and the developer may choose when to load them in-game. Limiting `duration` for each subtype specifies each subtype's use case and limits the asset file size.
 
-Other audio data such as `duration`, `channelCount`, and `sampleRate` is specific information for the game developer for loading the audio clip.
-
-The `engine` and `compression` allows the developer to filter assets and determine which file best to load. If the game developer cannot load any of the files, the NFT will not be loaded. The developer may also opt to add an unpackaged version (`engine` = `none`, `compression` = `raw`) that can be used by front-ends to preview an asset. These unpackaged version isn't packaged for any specific game engine.
+Audio data such as `duration` is specific information for the game developer for loading the audio clip, which may or may not be used.
 
 Once the metadata is loaded, the developer can choose which of the `assetProperties` to use if there is more than one.
 
-For this draft, we propose the following default audio type per game engine that an NFT should support. Each Audio NFT should have the following audio package and Rawrshak-enabled games should support it.
+This metadata framework draft is simple and contains only the most basic required information for an audio asset. It may be updated later on, more information such as channelCount and sampleRate may be added. Feedback from game developers and sound engineers may be necessary to determine additional information that is necessary.
 
-#### Unity
-```
-{
-    "engine": "unity",
-    "compression": "compressed"
-    "uri": "arweave.net/<transaction-id>",
-    "contentType": "audio/wav",
-    "duration": 1000,
-    "channelCount": 1,
-    "sampleRate": 44100
-}
-```
-
-For the Unity engine, the default compression should be 'compressed', default file extension should be '.wav', and the default sample rate should be 44.1 kHz (standard). 
 
 ## Samples
 
@@ -160,33 +130,21 @@ For the Unity engine, the default compression should be 'compressed', default fi
     [
         {
             "name": "unlockEffect.wav",
-            "engine": "none",
-            "compression": "raw",
             "uri": "arweave.net/<transaction-id>",
             "contentType": "audio/wav",
             "duration": "500",
-            "channelCount": 1,
-            "sampleRate": 44100
         },
         {
             "name": "unlockEffectWav",
-            "engine": "unity",
-            "compression": "compressed",
             "uri": "arweave.net/<transaction-id>",
             "contentType": "audio/wav",
             "duration": "500",
-            "channelCount": 1,
-            "sampleRate": 44100
         },
         {
             "name": "unlockEffectMp3",
-            "engine": "unity",
-            "compression": "compressed",
             "uri": "arweave.net/<transaction-id>",
             "contentType": "audio/mp3",
             "duration": "500",
-            "channelCount": 2,
-            "sampleRate": 48000
         }
     ],
     "devProperties":
@@ -214,33 +172,21 @@ For the Unity engine, the default compression should be 'compressed', default fi
     [
         {
             "name": "openingTheme.wav",
-            "engine": "none",
-            "compression": "raw",
             "uri": "arweave.net/<transaction-id>",
             "contentType": "audio/wav",
             "duration": "90000",
-            "channelCount": 2,
-            "sampleRate": 44100
         },
         {
             "name": "openingThemeWav",
-            "engine": "unity",
-            "compression": "compressed",
             "uri": "arweave.net/<transaction-id>",
             "contentType": "audio/wav",
             "duration": "90000",
-            "channelCount": 2,
-            "sampleRate": 44100
         },
         {
             "name": "openingThemeMp3",
-            "engine": "unity",
-            "compression": "compressed",
             "uri": "arweave.net/<transaction-id>",
             "contentType": "audio/mp3",
             "duration": "90000",
-            "channelCount": 2,
-            "sampleRate": 44100
         }
     ],
     "devProperties":

--- a/Drafts/Static3dObjectAssetMetadata.md
+++ b/Drafts/Static3dObjectAssetMetadata.md
@@ -4,8 +4,8 @@ status: Draft
 author: Christian Sumido (@gcbsumid)
 discussions-to: https://discord.gg/Ge2j4Cd65H
 created: 2021-11-09
-updated: 2021-11-13
-version: 0.1
+updated: 2022-01-31
+version: 0.2
 ---
 
 # Static 3D Object Asset Metadata
@@ -90,9 +90,7 @@ WebGL | Supported
 ### Levels of Fidelity
 We propose three levels of fidelity: Low-fidelity, Medium-fidelity, and High-fidelity. Low-fidelity is ideal for platform that have limited storage, memory, and CPU power. Mobile devices (Android and IOS) are the probable use-case for this. Low-fidelity assets allow for quick download and in-game loading. This is the recommended level of fidelity. Asset developers must support Low-Fidelity. Medium and High fidelity assets are for desktop platforms and should only be optional. Games expecting to be run on desktop or higher powered machines can load these assets by default if the developer or gamer chooses to do so.
 
-As of 11/13/21, we currently do not yet have a specific asset definition for the different Fidelity levels. We'd need to reach out to someone with more experience regarding this. This will be a framework and not a specific requirement as game developers should have the freedom to do what is best for their game. However, in order to make their assets useable in the ecosystem, they need to conform to a few guidelines. We'll most likely have some requirements per level such as file size and model vertex counts. 
-
-// Todo: Define the specific requirements and limits for Low, Medium, and High fidelity assets.
+As of 1/31/22, we currently only define fidelity with regards to the file size. We'd need to reach out to someone with more experience regarding this. This will be a framework and not a specific requirement as game developers should have the freedom to do what is best for their game. However, in order to make their assets useable in the ecosystem, they need to conform to a few guidelines. We'll most likely have some more requirements per level model vertex counts. Low will include assets less than or equal to 3mb. Medium will include assets greater than 3 mb but less than or equal to 10 mb. High will include assets anything greater than 10 mb.
 
 ### Asset Shapes
 There are several asset shapes (and default objects) that an asset must fit into. We provide bounding boxes to make sure an asset doesn't go beyond what the framework expects an asset's scale is to be. Based on an asset's shape, the game developer will place them in their game. The game developer is free to scale or rotate the prefab after loading, but game developers expect the asset's prefab to be within the shape's bounding box.
@@ -180,10 +178,9 @@ Decorations are static 3d objects that are acquired by users. There is no specif
 
 The `engine`, `renderPipeline`, and `platform` are properties that allow the game developer to filter the asset that they can load during runtime. These will be parsed by the subgraph and allow gamers to filter out assets they can use in a game.
 
-// gcbsumid - todo: discuss what fidelity does.
 The `fidelity` is used to allow game developers to load higher quality versions of an asset if they wish to provide it. Currently, fidelity only takes into account file size. 
 
-The `shape` allows game developers to figure the general shape of a Rawrshak asset. This allows developers to figure out which default asset to replace during runtime. 
+The `shape` allows game developers to figure the general shape of a Rawrshak asset. This allows developers to figure out which default asset to replace during runtime. It also gives soft guarantees that an asset will be within the shape's boundaries.
 
 ## Samples
 

--- a/Drafts/Static3dObjectAssetMetadata.md
+++ b/Drafts/Static3dObjectAssetMetadata.md
@@ -180,7 +180,8 @@ Decorations are static 3d objects that are acquired by users. There is no specif
 
 The `engine`, `renderPipeline`, and `platform` are properties that allow the game developer to filter the asset that they can load during runtime. These will be parsed by the subgraph and allow gamers to filter out assets they can use in a game.
 
-The `fidelity` is used to allow game developers to load higher quality versions of an asset if they wish to provide it.
+// gcbsumid - todo: discuss what fidelity does.
+The `fidelity` is used to allow game developers to load higher quality versions of an asset if they wish to provide it. Currently, fidelity only takes into account file size. 
 
 The `shape` allows game developers to figure the general shape of a Rawrshak asset. This allows developers to figure out which default asset to replace during runtime. 
 


### PR DESCRIPTION
Audio meta standards
- Removing some audio info including channel count, sample rate, compression, and engine.
- We're only going to support uploaded audio files, instead of the asset bundle packaged audio files.

3D static asset metadata
- Adding file size as a requirement for Fidelity information.